### PR TITLE
Fix typos and formatting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Looking to file bugs, request features or send feedback? File an issue or vote o
 
 HTTP Toolkit is primarily a desktop application. This repo contains the Android app, which connects to that desktop application, and forwards HTTP traffic there.
 
-The Android itself is effectively two parts:
+The Android app itself is effectively two parts:
 
 * An outer wrapper, which shows the UI, scans QR codes, retrieves proxy config from HTTP Toolkit, ensures the device trusts HTTP Toolkit's CA certificate, and starts and stops a VPN.
 * A VPN, which receives every IP packet sent by the device, parses them, rewrites some of them to go to HTTP Toolkit, and then sends the parsed requests on via the real network (and forwards responses back)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "tech.httptoolkit.android"
-    compileSdk =  35
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "tech.httptoolkit.android.v1"

--- a/app/src/main/java/tech/httptoolkit/android/QRScanActivity.kt
+++ b/app/src/main/java/tech/httptoolkit/android/QRScanActivity.kt
@@ -44,7 +44,7 @@ class QRScanActivity : Activity() {
         barcodeView!!.barcodeView.decoderFactory = DefaultDecoderFactory(listOf(BarcodeFormat.QR_CODE))
         barcodeView!!.initializeFromIntent(intent)
         barcodeView!!.decodeContinuous(callback)
-        barcodeView!!.setStatusText("Scan HTTPToolkit QR code to connect")
+        barcodeView!!.setStatusText("Scan HTTP Toolkit QR code to connect")
     }
 
     override fun onResume() {


### PR DESCRIPTION
This PR fixes the following issues:
1. Fixed a typo in README.md: Changed "The Android itself" to "The Android app itself"
2. Fixed formatting in app/build.gradle.kts: Removed extra space before "35"
3. Fixed formatting in QRScanActivity.kt