### PR TITLE
Fixed alternative HTTPS port

### DIFF
--- a/app/src/main/java/tech/httptoolkit/android/portfilter/PortConstants.kt
+++ b/app/src/main/java/tech/httptoolkit/android/portfilter/PortConstants.kt
@@ -15,7 +15,7 @@ val PORT_DESCRIPTIONS = mapOf(
     8008 to "Alternative HTTP port",
     8080 to "Popular local development HTTP port",
     8090 to "Popular local development HTTP port",
-    8433 to "Alternative HTTPS port",
+    8443 to "Alternative HTTPS port",
     8888 to "Popular local development HTTP port",
     9000 to "Popular local development HTTP port"
 )


### PR DESCRIPTION
`8443` is currently shown as [unknown port](https://github.com/httptoolkit/httptoolkit-android/blob/f23382de2f2104b813044c858bbe0176abecdff2/app/src/main/java/tech/httptoolkit/android/portfilter/PortListScreen.kt#L159)